### PR TITLE
Declare required dependencies in the META file

### DIFF
--- a/src/META
+++ b/src/META
@@ -1,4 +1,5 @@
 version         = "1.1.1"
 description     = "OCaml type for GPX representation, parser and printer."
+requires        = "ISO8601 xml-light"
 archive(byte)   = "gpx.cma"
 archive(native) = "gpx.cmxa"


### PR DESCRIPTION
I believe the dependencies should be declared explicitly in the META file.

For now it's necessary to specify these dependencies along with the `gpx` itself in the `_tags` file for `ocamlbuild`, or the program using `gpx` wouldn't compile:

```
Error: No implementations provided for the following modules:
         ISO8601 referenced from /home/arn/.opam/system/lib/gpx/gpx.cmxa(Gpx)
```
